### PR TITLE
Use immutable List instead of Array

### DIFF
--- a/lib/inline_rules.js
+++ b/lib/inline_rules.js
@@ -125,7 +125,7 @@ function addProperty(map, newProperty) {
 // Map(name, property) -> string
 function getStyleAttribute(properties) {
   if (properties.size > 0) {
-    const values = Array.from(properties.values());
+    const values = Immutable.List(properties.values());
     const pairs  = values.map(property => `${property.name}:${property.value}`);
     return pairs.join(';');
   } else


### PR DESCRIPTION
But, in reality, allows css-inliner to be used in environments where collections/shim was required.
