### PR TITLE
Only empty elements (as defined in XHTML DTD) can use </> shorthand

### DIFF
--- a/lib/dom_to_html.js
+++ b/lib/dom_to_html.js
@@ -38,7 +38,7 @@ function stringifyNodes(nodes, stack) {
     else if (node.type === ElementType.Directive) {
       const isDoctype = (i === 0);
       if (isDoctype && isXHTML(node))
-        stack.get(0).isXML = true;
+        stack.get(0).isXHTML = true;
       return stringifyDirective(node);
     }
 
@@ -111,6 +111,21 @@ const UNENCODED_ELEMENTS = Immutable.Set([
 ]);
 
 
+// Elements that can use the empty element shorthand in XHTML (<tag />).
+const XHTML_EMPTY_ELEMENTS = Immutable.Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param'
+]);
+
+
 // Stringify an element and all its children
 function stringifyElement(element, stack) {
   const name        = element.name;
@@ -122,9 +137,12 @@ function stringifyElement(element, stack) {
   const content     = stringifyNodes(children, nextStack);
 
   const isSVG       = !!nextStack.find(element => element.name === 'svg');
-  const isXML       = stack.get(0).isXML || isSVG;
+  const isXHTML     = stack.get(0).isXHTML;
 
-  if (isXML) {
+  if (isXHTML) {
+    const isSelfClosing = !content && XHTML_EMPTY_ELEMENTS.has(name);
+    return isSelfClosing ? `<${openTag}/>` : `<${openTag}>${content}</${name}>`;
+  } else if (isSVG) {
     const isSelfClosing = !content;
     return isSelfClosing ? `<${openTag}/>` : `<${openTag}>${content}</${name}>`;
   } else {

--- a/lib/dom_to_html.js
+++ b/lib/dom_to_html.js
@@ -38,7 +38,7 @@ function stringifyNodes(nodes, stack) {
     else if (node.type === ElementType.Directive) {
       const isDoctype = (i === 0);
       if (isDoctype && isXHTML(node))
-        stack.get(0).isXML = true;
+        stack.get(0).isXHTML = true;
       return stringifyDirective(node);
     }
 
@@ -127,7 +127,7 @@ function stringifyElement(element, stack) {
   const isForeign     = !!nextStack.find(element => element.name === 'svg');
   // XML production rules apply to either XHTML documents or foreign elements
   // in HTML5 documents
-  const isXML         = stack.get(0).isXML || isForeign;
+  const isXML         = stack.get(0).isXHTML || isForeign;
   const isVoidElement = VOID_ELEMENTS.has(name);
 
   if (isXML) {

--- a/lib/dom_to_html.js
+++ b/lib/dom_to_html.js
@@ -121,16 +121,27 @@ function stringifyElement(element, stack) {
   const nextStack   = stack.push(element);
   const content     = stringifyNodes(children, nextStack);
 
-  const isSVG       = !!nextStack.find(element => element.name === 'svg');
-  const isXML       = stack.get(0).isXML || isSVG;
+  // In HTML5 SVG and MathML are "foreign elements", they have the same
+  // production rules as XML, specifically empty elements can use self-closing
+  // tags (smaller output)
+  const isForeign     = !!nextStack.find(element => element.name === 'svg');
+  // XML production rules apply to either XHTML documents or foreign elements
+  // in HTML5 documents
+  const isXML         = stack.get(0).isXML || isForeign;
+  const isVoidElement = VOID_ELEMENTS.has(name);
 
   if (isXML) {
-    const isSelfClosing = !content;
+    // In XHTML void elements have an empty content model, and so should use
+    // self-closing tags (which also parses as HTML), but elements with a
+    // content model must use open and close tags, even if they have no content
+    // (e.g. parsers choke on <title />)
+    //
+    // Foreign elements (SVG/MathML in HTML5) can deal with self-closing tags
+    const isSelfClosing = isVoidElement || (isForeign && !content);
     return isSelfClosing ? `<${openTag} />` : `<${openTag}>${content}</${name}>`;
-  } else {
-    const isVoidElement = VOID_ELEMENTS.has(name);
+  } else
+    // In HTML void elements have no content, only use a single tag (implied close)
     return isVoidElement ? `<${openTag}>` : `<${openTag}>${content}</${name}>`;
-  }
 }
 
 

--- a/lib/dom_to_html.js
+++ b/lib/dom_to_html.js
@@ -111,21 +111,6 @@ const UNENCODED_ELEMENTS = Immutable.Set([
 ]);
 
 
-// Elements that can use the empty element shorthand in XHTML (<tag />).
-const XHTML_EMPTY_ELEMENTS = Immutable.Set([
-  'area',
-  'base',
-  'br',
-  'col',
-  'hr',
-  'img',
-  'input',
-  'link',
-  'meta',
-  'param'
-]);
-
-
 // Stringify an element and all its children
 function stringifyElement(element, stack) {
   const name        = element.name;

--- a/lib/dom_to_html.js
+++ b/lib/dom_to_html.js
@@ -38,7 +38,7 @@ function stringifyNodes(nodes, stack) {
     else if (node.type === ElementType.Directive) {
       const isDoctype = (i === 0);
       if (isDoctype && isXHTML(node))
-        stack.get(0).isXHTML = true;
+        stack.get(0).isXML = true;
       return stringifyDirective(node);
     }
 
@@ -137,12 +137,9 @@ function stringifyElement(element, stack) {
   const content     = stringifyNodes(children, nextStack);
 
   const isSVG       = !!nextStack.find(element => element.name === 'svg');
-  const isXHTML     = stack.get(0).isXHTML;
+  const isXML       = stack.get(0).isXML || isSVG;
 
-  if (isXHTML) {
-    const isSelfClosing = !content && XHTML_EMPTY_ELEMENTS.has(name);
-    return isSelfClosing ? `<${openTag} />` : `<${openTag}>${content}</${name}>`;
-  } else if (isSVG) {
+  if (isXML) {
     const isSelfClosing = !content;
     return isSelfClosing ? `<${openTag} />` : `<${openTag}>${content}</${name}>`;
   } else {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/broadly/css-linter.git"
+    "url": "git+https://github.com/broadly/css-inliner.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/broadly/css-linter/issues"
+    "url": "https://github.com/broadly/css-inliner/issues"
   },
-  "homepage": "https://github.com/broadly/css-linter#readme"
+  "homepage": "https://github.com/broadly/css-inliner#readme"
 }

--- a/test/dom_to_html_test.js
+++ b/test/dom_to_html_test.js
@@ -184,10 +184,12 @@ describe('DOM to HTML', function() {
 
 
   describe('an XHTML document', function() {
-    const xhtml     = File.readFileSync(`${__dirname}/xhtml.html`, 'utf8');
-    const expected  = xhtml;
-    const actual    = roundTrip(xhtml);
-    assert.equal(actual, expected);
+    it('should produce itself', function() {
+      const xhtml     = File.readFileSync(`${__dirname}/xhtml.html`, 'utf8');
+      const expected  = xhtml;
+      const actual    = roundTrip(xhtml);
+      assert.equal(actual, expected);
+    });
   });
 
 });

--- a/test/dom_to_html_test.js
+++ b/test/dom_to_html_test.js
@@ -192,5 +192,25 @@ describe('DOM to HTML', function() {
     });
   });
 
+  describe('XHTML mode', function() {
+    describe('a regular element with no content', function() {
+      it('should not use the </> shorthand', function() {
+        const html      = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><title></title></html>';
+        const expected  = html;
+        const actual    = roundTrip(html);
+        assert.equal(actual, expected);
+      });
+    });
+
+    describe('an empty element with no content', function() {
+      it('should use the </> shorthand', function() {
+        const html      = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><br/></html>';
+        const expected  = html;
+        const actual    = roundTrip(html);
+        assert.equal(actual, expected);
+      });
+    });
+  });
+
 });
 


### PR DESCRIPTION
See #13.