### PR TITLE
Use a space before the trailing `/>` of empty elements

### DIFF
--- a/lib/dom_to_html.js
+++ b/lib/dom_to_html.js
@@ -141,10 +141,10 @@ function stringifyElement(element, stack) {
 
   if (isXHTML) {
     const isSelfClosing = !content && XHTML_EMPTY_ELEMENTS.has(name);
-    return isSelfClosing ? `<${openTag}/>` : `<${openTag}>${content}</${name}>`;
+    return isSelfClosing ? `<${openTag} />` : `<${openTag}>${content}</${name}>`;
   } else if (isSVG) {
     const isSelfClosing = !content;
-    return isSelfClosing ? `<${openTag}/>` : `<${openTag}>${content}</${name}>`;
+    return isSelfClosing ? `<${openTag} />` : `<${openTag}>${content}</${name}>`;
   } else {
     const isVoidElement = VOID_ELEMENTS.has(name);
     return isVoidElement ? `<${openTag}>` : `<${openTag}>${content}</${name}>`;

--- a/test/dom_to_html_test.js
+++ b/test/dom_to_html_test.js
@@ -125,7 +125,7 @@ describe('DOM to HTML', function() {
     describe('(XML in HTML, empty)', function() {
       it('should produce self-closing tag', function() {
         const html      = '<svg autofocus></svg>';
-        const expected  = '<svg autofocus/>';
+        const expected  = '<svg autofocus />';
         const actual    = roundTrip(html);
         assert.equal(actual, expected);
       });
@@ -133,7 +133,7 @@ describe('DOM to HTML', function() {
 
     describe('(XML in HTML)', function() {
       it('should produce element and contents', function() {
-        const html      = '<svg><rect/><path/></svg>';
+        const html      = '<svg><rect /><path /></svg>';
         const expected  = html;
         const actual    = roundTrip(html);
         assert.equal(actual, expected);
@@ -204,7 +204,7 @@ describe('DOM to HTML', function() {
 
     describe('an empty element with no content', function() {
       it('should use the </> shorthand', function() {
-        const html      = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><br/></html>';
+        const html      = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><br /></html>';
         const expected  = html;
         const actual    = roundTrip(html);
         assert.equal(actual, expected);

--- a/test/xhtml.html
+++ b/test/xhtml.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <meta name="viewport" content="width=device-width"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>{{subject}}</title>
-    <link rel="stylesheet" href="email/default.less"/>
+    <link rel="stylesheet" href="email/default.less" />
   </head>
   <body>
     <table class="body">
@@ -23,6 +23,6 @@
         </td>
       </tr>
     </table>
-    <br/>
+    <br />
   </body>
 </html>


### PR DESCRIPTION
As suggested by XHTML spec: http://www.w3.org/TR/xhtml1/#C_2
