### PR TITLE
Support for at-rules with no content

### DIFF
--- a/lib/add_rules.js
+++ b/lib/add_rules.js
@@ -21,8 +21,7 @@ module.exports = function addRules(context) {
 
   if (rules.size > 0) {
     debug('%s: Adding <style> element to document', context.filename);
-    const compress      = context.compress;
-    const styleElement  = rulesToStyleElement(rules, compress);
+    const styleElement  = rulesToStyleElement(rules);
     insertStyleElement(dom, styleElement);
   }
 
@@ -32,8 +31,8 @@ module.exports = function addRules(context) {
 
 
 // Returns the <style> element with all remaining rules
-function rulesToStyleElement(rules, compress) {
-  const css           = stringifyRules(rules, compress);
+function rulesToStyleElement(rules) {
+  const css           = stringifyRules(rules);
   const textNode      = {
     type: ElementType.Text,
     data: css

--- a/lib/context.js
+++ b/lib/context.js
@@ -26,8 +26,6 @@ module.exports = Immutable.Record({
   // htmlparser2 DOM; mutated between stages
   dom:          null,
   // List of CSS rules, updated (not mutated) between stages
-  rules:        null,
-  // True to compress output
-  compress:     false
+  rules:        null
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,6 @@ module.exports = class CSSInliner extends EventEmitter {
   // Construct a new CSS inliner.
   //
   // Supported options:
-  // compress   - True to compress output (default)
   // directory  - Directory to load CSS resources from (defaults to cwd)
   // loadAsync  - Load CSS from path name, resolves to Buffer/String
   // plugins    - Array of PostCSS plugins to use
@@ -44,9 +43,8 @@ module.exports = class CSSInliner extends EventEmitter {
     super();
     options = options || {};
     const cache     = new Cache(options);
-    const compress  = (options.compress) === false ? false : true;
     const template  = options.template;
-    this._context   = new Context({ cache, compress, inliner: this, template });
+    this._context   = new Context({ cache, inliner: this, template });
 
     // Default handler for reporting any warnings
     this.on('warning', this._onWarning.bind(this));

--- a/lib/stringify_rules.js
+++ b/lib/stringify_rules.js
@@ -37,9 +37,11 @@ function stringifyDontCompress(rules) {
 function stringifyRule(rule) {
   switch (rule.type) {
     case 'atrule': {
-      const childRules  = rule.nodes;
-      const atRuleBody  = stringifyAndCompress(childRules);
-      return `@${rule.name} ${rule.params}{${atRuleBody}}`;
+      if (rule.nodes) {
+        const atRuleBody  = stringifyAndCompress(rule.nodes);
+        return `@${rule.name} ${rule.params}{${atRuleBody}}`;
+      } else
+        return `@${rule.name} ${rule.params};`;
     }
     case 'rule': {
       const selectors     = stringifySelectors(rule);

--- a/lib/stringify_rules.js
+++ b/lib/stringify_rules.js
@@ -1,32 +1,17 @@
 // Convert PostCSS rules back into CSS text.
-//
-// PostCSS has a toString() method, but it preserves comments and whitespace,
-// and we have an option to compress the output by stripping unnecesssary junk.
 
 'use strict';
 
 
-// Call with a list of rules, and whether or not we want to compress the CSS.
-module.exports = function stringifyRules(rules, compress) {
-  const css = compress ?
-    stringifyAndCompress(rules) :
-    stringifyDontCompress(rules);
-  return css;
-};
-
+module.exports = stringifyAllRules;
 
 // PostCSS rules -> string
 //
 // Since rules may contain other rules (e.g. media queries) this is recursive by
 // means of stringifyRule
-function stringifyAndCompress(rules) {
-  return rules.map(stringifyRule).join('');
-}
-
-
-// PostCSS rules -> string
-function stringifyDontCompress(rules) {
-  return rules.map(rule => rule.toString()).join('\n');
+function stringifyAllRules(rules) {
+  const css = rules.map(stringifyRule).join('');
+  return css;
 }
 
 
@@ -38,7 +23,7 @@ function stringifyRule(rule) {
   switch (rule.type) {
     case 'atrule': {
       if (rule.nodes) {
-        const atRuleBody  = stringifyAndCompress(rule.nodes);
+        const atRuleBody  = stringifyAllRules(rule.nodes);
         return `@${rule.name} ${rule.params}{${atRuleBody}}`;
       } else
         return `@${rule.name} ${rule.params};`;

--- a/test/add_rules_test.js
+++ b/test/add_rules_test.js
@@ -4,22 +4,12 @@ const assert    = require('assert');
 const Cache     = require('../lib/cache');
 const Context   = require('../lib/context');
 const domToHTML = require('../lib/dom_to_html');
-const DOMUtils  = require('domutils');
 const parseHTML = require('../lib/parse_html');
 
 
 describe('Add rules', function() {
 
-  const css =
-`@media print {
-  .footer {
-    display: none;
-  }
-}
-h1:hover,  h1:before  {
-  color : red ;
-  background: none ;
-}`;
+  const css = `@media print{.footer{display:none}}h1:hover,h1:before{color:red;background:none}`;
 
   function parseAndAddRules(html) {
     const cache = new Cache();

--- a/test/stringify_rules_test.js
+++ b/test/stringify_rules_test.js
@@ -35,27 +35,10 @@ h1:hover,  h1:before  {
       });
   });
 
-  describe('without compression', function() {
-
-    it('should produce same CSS minus empty lines', function() {
-      const expected  = source.replace(/\n+/gm, '\n').trim();
-      const actual    = stringifyRules(rules, false);
-      console.log(rules)
-      console.log(actual)
-      assert.equal(actual, expected);
-    });
-
-  });
-
-  describe('with compression', function() {
-
-
-    it('should squeeze spaces and comments out of the CSS', function() {
-      const expected  = `@charset "UTF-8";@media print{.footer{display:none}}h1:hover,h1:before{color:red;background:none !important}`;
-      const actual    = stringifyRules(rules, true);
-      assert.equal(actual, expected);
-    });
-
+  it('should squeeze spaces and comments out of the CSS', function() {
+    const expected  = `@charset "UTF-8";@media print{.footer{display:none}}h1:hover,h1:before{color:red;background:none !important}`;
+    const actual    = stringifyRules(rules, true);
+    assert.equal(actual, expected);
   });
 
 });

--- a/test/stringify_rules_test.js
+++ b/test/stringify_rules_test.js
@@ -7,6 +7,7 @@ const stringifyRules  = require('../lib/stringify_rules');
 describe('Stringify rules', function() {
 
   const source = `
+@charset "UTF-8";
 
 /* Media rules for printers */
 @media print {
@@ -39,6 +40,8 @@ h1:hover,  h1:before  {
     it('should produce same CSS minus empty lines', function() {
       const expected  = source.replace(/\n+/gm, '\n').trim();
       const actual    = stringifyRules(rules, false);
+      console.log(rules)
+      console.log(actual)
       assert.equal(actual, expected);
     });
 
@@ -48,7 +51,7 @@ h1:hover,  h1:before  {
 
 
     it('should squeeze spaces and comments out of the CSS', function() {
-      const expected  = `@media print{.footer{display:none}}h1:hover,h1:before{color:red;background:none !important}`;
+      const expected  = `@charset "UTF-8";@media print{.footer{display:none}}h1:hover,h1:before{color:red;background:none !important}`;
       const actual    = stringifyRules(rules, true);
       assert.equal(actual, expected);
     });


### PR DESCRIPTION
Add support for at-rules that have no content, such as `@import` and `@chartset`.

This PR also disables the `compress` option for now. That option was mostly for debugging, so not a critical feature, and the no-compress code couldn’t handle no-content at-rules.