### PR TITLE
Fix issue with nesting and attribute selectors

### DIFF
--- a/lib/parse_html.js
+++ b/lib/parse_html.js
@@ -42,6 +42,7 @@ module.exports = function parseHTML(context) {
 function createRootNode(nodes) {
   const root  = {
     type:     'root',
+    attribs:  {},
     children: nodes
   };
   for (let node of nodes)

--- a/test/inline.style.css
+++ b/test/inline.style.css
@@ -22,3 +22,9 @@ p:hover {
     font-weight: bolder;
   }
 }
+
+/* Make sure nested selectors below an attribute selector don't throw.
+ * This shouldn't match any element in the DOM. */
+div[itemscope] p {
+  color: black;
+}


### PR DESCRIPTION
The problem is that the DOM is traversed up until our root element, which has no attributes, so css-select chokes.
