### PR TITLE
Keep declaration order when inlining into style attribute.

### DIFF
--- a/lib/inline_rules.js
+++ b/lib/inline_rules.js
@@ -103,11 +103,11 @@ function getPropertiesFromElement(element) {
     const decls       = PostCSS.parse(styleAttribute).nodes;
     const properties  = decls
       .map(decl => toProperty('1000', decl))
-      .reduce(addProperty, Immutable.Map());
+      .reduce(addProperty, Immutable.OrderedMap());
     return properties;
 
   } else
-    return Immutable.Map();
+    return Immutable.OrderedMap();
 }
 
 

--- a/test/inline_rules_test.js
+++ b/test/inline_rules_test.js
@@ -313,6 +313,90 @@ describe('Apply rules inline', function() {
 
   });
 
+  describe('with many declarations', function() {
+
+    const css   = `
+      a {
+        font-family:      sans-serif;
+        font-size:        14px;
+        line-height:      1;
+        margin:           0;
+        padding:          0;
+      }
+      div.button a {
+        background:       #2ba6cb;
+      }
+      .buttons div.button a {
+        background-color: #337ab7;
+        border-color:     #2e6da4;
+        color:            #fff;
+      }
+    `;
+
+    let dom;
+
+    describe('an element with no style attribute', function() {
+      const html  = `
+      <html>
+        <body>
+          <div class="buttons">
+            <div class="button">
+              <a>Click me</a>
+            </div>
+          </div>
+        </body>
+      </html>
+      `;
+
+      before(function() {
+        return applyCSS(html, css)
+          .then(function(result) {
+            dom = result;
+          });
+      });
+
+      it('should keep declarations in order', function() {
+        const link            = CSSselect.selectOne('a', dom);
+        const background      = link.attribs.style.indexOf('background:');
+        const backgroundColor = link.attribs.style.indexOf('background-color:');
+
+        assert(background      > -1);
+        assert(backgroundColor > -1);
+        assert(backgroundColor > background);
+      });
+    });
+
+    describe('an element with a style attribute', function() {
+      const html  = `
+      <html>
+        <body>
+          <div class="buttons">
+            <div class="button">
+              <a style='display: block'>Click me</a>
+            </div>
+          </div>
+        </body>
+      </html>
+      `;
+
+      before(function() {
+        return applyCSS(html, css)
+          .then(function(result) {
+            dom = result;
+          });
+      });
+
+      it('should keep declarations in order', function() {
+        const link            = CSSselect.selectOne('a', dom);
+        const background      = link.attribs.style.indexOf('background:');
+        const backgroundColor = link.attribs.style.indexOf('background-color:');
+
+        assert(background      > -1);
+        assert(backgroundColor > -1);
+        assert(backgroundColor > background);
+      });
+    });
+  });
 
 });
 


### PR DESCRIPTION
Immutable's Map iteration order is not guaranteed. However, this bug is  only triggered when there are at least 9 declarations to apply. Probably due to implementation details (I looked briefly but couldn't trace this to Immutable, so maybe it's Node/V8).

This is especially relevant with shorthand properties. For instance, `background: red` and `background-color: blue` are different declarations, but in fact one overrides the other, so order is important.
